### PR TITLE
fix: Add [byDateDesc.length] as dependencies to useEffect

### DIFF
--- a/Debuggez-une-application-React.JS-main/src/containers/Slider/index.js
+++ b/Debuggez-une-application-React.JS-main/src/containers/Slider/index.js
@@ -20,7 +20,7 @@ const Slider = () => {
 
   useEffect(() => {
     nextCard();    
-  }, [index]);
+  }, [index, byDateDesc.length]);
 
   return (
       <div className="SlideCardList">


### PR DESCRIPTION
- Modified `useEffect` to include `[index, byDateDesc.length]` as dependencies, ensuring `nextCard()` runs on both index and data length changes, so the carousel starts correctly.